### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Encore
         use: {
             loader: 'elm-webpack-loader',
             options: {
-                pathToMake: 'node_modules/.bin/elm-make',
+                pathToElm: 'node_modules/.bin/elm',
                 debug: !Encore.isProduction(),
                 optimize: Encore.isProduction()
             }


### PR DESCRIPTION
Update supported option 'pathToElm' formerly 'pathToMake'.
That option has been updated in elm-webpack-loader at: https://github.com/elm-community/elm-webpack-loader/pull/156